### PR TITLE
Update CI tests to only run on PR

### DIFF
--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -1,8 +1,6 @@
 name: CI Tests
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
No need to run on Push since all merges require a PR